### PR TITLE
Improve homepage performance

### DIFF
--- a/static/templates/base.jinja2
+++ b/static/templates/base.jinja2
@@ -15,6 +15,9 @@
     <meta name="apple-mobile-web-app-capable" content="yes">
     <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
 
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+
     {% block headers %}
     {% endblock %}
 
@@ -51,10 +54,10 @@
         f.parentNode.insertBefore(j, f);
     })(window, document, 'script', 'dataLayer', 'GTM-MMLBMCK');</script>
 
-    <script src="{{ static_url }}/libs/jquery-3.2.1.min.js"></script>
+    <script defer src="{{ static_url }}/libs/jquery-3.2.1.min.js"></script>
 
 
-    <script src="https://www.gstatic.com/firebasejs/5.9.1/firebase.js"></script>
+    <script defer src="https://www.gstatic.com/firebasejs/5.9.1/firebase.js"></script>
 
     <script>
         // Initialize Firebase

--- a/static/templates/shared/index.jinja2
+++ b/static/templates/shared/index.jinja2
@@ -527,43 +527,43 @@ Answer:
         <div class="carousel-container">
             <div class="carousel-track">
                 <div class="carousel-slide">
-                    <img src="{{ static_url }}/img/canva.jpeg" alt="Canva" class="hero-trusted-image">
+                    <img src="{{ static_url }}/img/canva.jpeg" alt="Canva" class="hero-trusted-image" width="200" height="200" loading="lazy" decoding="async">
                     <span class="carousel-tooltip">Canva</span>
                 </div>
                 <div class="carousel-slide">
                     <a href="https://netwrck.com" target="_blank">
-                        <img src="{{ static_url }}/img/netwrck-logo-colord256.png" alt="Netwrck" class="hero-trusted-image">
+                        <img src="{{ static_url }}/img/netwrck-logo-colord256.png" alt="Netwrck" class="hero-trusted-image" width="256" height="256" loading="lazy" decoding="async">
                     </a>
                     <span class="carousel-tooltip">Netwrck</span>
                 </div>
 
                 <div class="carousel-slide">
                     <a href="https://ebank.nz">
-                        <img src="{{ static_url }}/img/ebank-logo-removebg-full387.webp" alt="eBank" class="hero-trusted-image">
+                        <img src="{{ static_url }}/img/ebank-logo-removebg-full387.webp" alt="eBank" class="hero-trusted-image" width="387" height="387" loading="lazy" decoding="async">
                     </a>
                     <span class="carousel-tooltip">eBank Art Generator</span>
                 </div>
                 <div class="carousel-slide">
                     <a href="https://addictingwordgames.com">
-                        <img src="{{ static_url }}/img/addicting-word-games-icon200.png" alt="Addictingwordgames" class="hero-trusted-image">
+                        <img src="{{ static_url }}/img/addicting-word-games-icon200.png" alt="Addictingwordgames" class="hero-trusted-image" width="200" height="200" loading="lazy" decoding="async">
                     </a>
                     <span class="carousel-tooltip">Addicting Word Games</span>
                 </div>
                 <div class="carousel-slide">
-                    <img src="{{ static_url }}/img/journeai-logo.svg" alt="Journeai.com" class="hero-trusted-image">
+                    <img src="{{ static_url }}/img/journeai-logo.svg" alt="Journeai.com" class="hero-trusted-image" width="454" height="110" loading="lazy" decoding="async">
                     <span class="carousel-tooltip">Journeai</span>
                 </div>
                 <div class="carousel-slide">
-                    <img src="{{ static_url }}/img/copymattic.jpeg" alt="Copymattic" class="hero-trusted-image">
+                    <img src="{{ static_url }}/img/copymattic.jpeg" alt="Copymattic" class="hero-trusted-image" width="200" height="200" loading="lazy" decoding="async">
                     <span class="carousel-tooltip">Copymattic</span>
                 </div>
                 <div class="carousel-slide">
-                    <img src="{{ static_url }}/img/nsw-government-logo.svg" alt="NSW" class="hero-trusted-image">
+                    <img src="{{ static_url }}/img/nsw-government-logo.svg" alt="NSW" class="hero-trusted-image" width="71" height="76" loading="lazy" decoding="async">
                     <span class="carousel-tooltip">NSW Government Australia</span>
                 </div>
                 
                 <div class="carousel-slide">
-                    <img src="{{ static_url }}/img/cairo-university.png" alt="Cairo University" class="hero-trusted-image">
+                    <img src="{{ static_url }}/img/cairo-university.png" alt="Cairo University" class="hero-trusted-image" width="600" height="500" loading="lazy" decoding="async">
                     <span class="carousel-tooltip">Cairo University</span>
                 </div>
                 


### PR DESCRIPTION
## Summary
- add preconnect links to fonts
- defer heavy scripts in base template
- add widths, heights and lazy loading to home page logos

## Testing
- `pytest -q` *(fails: command not found)*