### PR TITLE
Remove ads and add speech-to-text page

### DIFF
--- a/main.py
+++ b/main.py
@@ -666,6 +666,16 @@ async def text_to_speech(request: Request):
         "templates/text-to-speech.jinja2", base_vars,
     )
 
+
+@app.get("/speech-to-text")
+async def speech_to_text(request: Request):
+    base_vars = get_base_template_vars(request)
+    base_vars.update({
+    })
+    return templates.TemplateResponse(
+        "templates/speech-to-text.jinja2", base_vars,
+    )
+
 @app.get("/use-cases/{usecase}")
 async def use_case_route(request: Request, usecase: str):
     use_case_data = deepcopy(fixtures.use_cases.get(usecase))

--- a/static/openapi.json
+++ b/static/openapi.json
@@ -5,6 +5,9 @@
     "description": "Generate text, create chat bots, perform question answering, classification, language translation, prediction across a variety of domains via 'prompt engineering' asking questions in a familiar way to human conversation. \n Under the hood we use very large language models trained on broad human language.  \n * control stopping criteria and cost\n * `max_length` for a maximum amount of tokens \n * `max_sentences` for setting a max number of sentences, good for conversational agents or when you know how many sentences should be generated\n * `stopping_sequences` a list of sequences that once generated signal the end of text generation, give some examples of when these should appear in your prompt, these wont be output at the end if used to stop. \n * control the variety of results \n * get more results with `number_of_results`\n * higher `top_p`, lower `top_k` for high variety/creativity \n * low `top_p` and high `top_k` for consistency\n * low `temperature` for consistency, high for creativity\n * when generating shorter sequences you may want to choose settings that give higher consistency and are more likely, when generating long sequences you may want to use settings that are give more surprise/creativity, defaults should work well for both.",
     "version": "1"
   },
+
+  "servers": [{"url": "https://api.text-generator.io"}],
+
   "paths": {
     "/api/v1/feature-extraction": {
       "post": {

--- a/static/templates-game/macros.jinja2
+++ b/static/templates-game/macros.jinja2
@@ -72,15 +72,3 @@
 {%- endmacro %}
 
 
-{%- macro responsiveAd() %}
-    <script async src="//pagead2.googlesyndication.com/pagead/js/adsbygoogle.js"></script>
-    <!-- responsiveAd -->
-    <ins class="adsbygoogle"
-         style="display:block"
-         data-ad-client="ca-pub-7026363262140448"
-         data-ad-slot="9824934150"
-         data-ad-format="auto"></ins>
-    <script>
-        (adsbygoogle = window.adsbygoogle || []).push({});
-    </script>
-{%- endmacro %}

--- a/static/templates/macros.jinja2
+++ b/static/templates/macros.jinja2
@@ -47,19 +47,6 @@
 {%- endmacro %}
 
 
-{%- macro responsiveAd() %}
-    <script async src="//pagead2.googlesyndication.com/pagead/js/adsbygoogle.js"></script>
-    <!-- responsiveAd -->
-    <ins class="adsbygoogle"
-         style="display:block"
-         data-ad-client="ca-pub-7026363262140448"
-         data-ad-slot="9824934150"
-         data-ad-format="auto"></ins>
-    <script>
-        (adsbygoogle = window.adsbygoogle || []).push({});
-    </script>
-
-{%- endmacro %}
 
 {% macro svgstyled() -%}
 <svg class="svg-hero-left" width="100%" height="747" viewBox="0 0 1684 747" fill="none" xmlns="http://www.w3.org/2000/svg" style="width: 200%;left: -561px">

--- a/static/templates/shared/header.jinja2
+++ b/static/templates/shared/header.jinja2
@@ -38,6 +38,7 @@
         <a class="mdl-navigation__link" href="/playground"><i class="material-icons dp48">play_arrow</i> Playground</a>
         <a class="mdl-navigation__link" href="/ai-text-editor"><i class="material-icons dp48">edit</i> AI Text Editor</a>
         <a class="mdl-navigation__link" href="/text-to-speech"><i class="material-icons dp48">volume_up</i> Text To Speech</a>
+        <a class="mdl-navigation__link" href="/speech-to-text"><i class="material-icons dp48">graphic_eq</i> Speech To Text</a>
         <a class="mdl-navigation__link" href="/docs"><i class="material-icons dp48">android</i> Docs</a>
         <a class="header-login-signup mdl-navigation__link" href="/login"><i class="material-icons dp48">login</i> Login</a>
         <a class="header-subscribe mdl-navigation__link" href="/subscribe"><i class="material-icons dp48">payments</i> Subscribe</a>

--- a/static/templates/shared/speech-to-text.jinja2
+++ b/static/templates/shared/speech-to-text.jinja2
@@ -1,0 +1,138 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>{{ title }}</title>
+    <style>
+        body {
+            font-family: sans-serif;
+        }
+        .demo-ribbon {
+            width: 100%;
+            height: 40vh;
+            background-color: #3F51B5;
+            flex-shrink: 0;
+        }
+        .demo-main {
+            margin-top: -35vh;
+            flex-shrink: 0;
+        }
+        .demo-container {
+            max-width: 1600px;
+            width: calc(100% - 16px);
+            margin: 0 auto;
+        }
+        .demo-content {
+            border-radius: 2px;
+            padding: 40px 56px;
+            margin-bottom: 80px;
+        }
+        .stt-container {
+            max-width: 600px;
+            margin: 0 auto;
+        }
+        .hidden { display: none; }
+    </style>
+</head>
+<body>
+<div class="demo-ribbon"></div>
+<main class="demo-main mdl-layout mdl-layout__content">
+    <div class="demo-container mdl-grid">
+        <div class="demo-content mdl-color--white mdl-shadow--4dp mdl-color-text--grey-800 mdl-cell mdl-cell--8-col">
+            <div class="stt-container">
+                <h3>Speech To Text Playground</h3>
+                <div class="mdl-textfield mdl-js-textfield">
+                    <input class="mdl-textfield__input" type="text" id="audioUrl" placeholder="Audio URL">
+                </div>
+                <div>
+                    <input type="file" id="audioFile" accept="audio/*">
+                </div>
+                <label class="mdl-checkbox mdl-js-checkbox mdl-js-ripple-effect" for="translate">
+                    <input type="checkbox" id="translate" class="mdl-checkbox__input">
+                    <span class="mdl-checkbox__label">Translate to English</span>
+                </label>
+                <br>
+                <button id="runUrl" class="mdl-button mdl-js-button mdl-button--raised mdl-button--colored">Transcribe URL</button>
+                <button id="runFile" class="mdl-button mdl-js-button mdl-button--raised mdl-button--colored">Transcribe File</button>
+                <pre id="result"></pre>
+                <button id="toggleCode" class="mdl-button mdl-js-button">Show Code</button>
+                <div id="codeExamples" class="hidden">
+                    <h4>cURL</h4>
+<pre><code>curl -X POST "https://api.text-generator.io/api/v1/audio-extraction" \
+ -H "Content-Type: application/json" \
+ -H "secret: YOUR_API_KEY" \
+ -d '{
+  "audio_url": "AUDIO_URL",
+  "translate_to_english": false
+}'
+
+curl -X POST "https://api.text-generator.io/api/v1/audio-file-extraction" \
+ -H "secret: YOUR_API_KEY" \
+ -F "audio_file=@your_file.wav" \
+ -F "translate_to_english=false"
+</code></pre>
+                    <h4>Python</h4>
+<pre><code>import requests
+
+headers = {"secret": "YOUR_API_KEY"}
+
+data = {
+    "audio_url": "AUDIO_URL",
+    "translate_to_english": False
+}
+url = "https://api.text-generator.io/api/v1/audio-extraction"
+print(requests.post(url, json=data, headers=headers).json())
+</code></pre>
+                </div>
+            </div>
+        </div>
+    </div>
+</main>
+<script>
+    const runUrlBtn = document.getElementById('runUrl');
+    const runFileBtn = document.getElementById('runFile');
+    const resultEl = document.getElementById('result');
+    const codeBtn = document.getElementById('toggleCode');
+    const codeExamples = document.getElementById('codeExamples');
+    let secret = null;
+    if (typeof firebase !== 'undefined') {
+        firebase.auth().onAuthStateChanged(function(user) {
+            if (user) {
+                getUserWithStripe(user, function(data){
+                    secret = data['secret'];
+                });
+            }
+        });
+    }
+    codeBtn.addEventListener('click', () => {
+        codeExamples.classList.toggle('hidden');
+    });
+    runUrlBtn.addEventListener('click', async () => {
+        const audioUrl = document.getElementById('audioUrl').value;
+        const translate = document.getElementById('translate').checked;
+        if (!audioUrl) { alert('Enter audio URL'); return; }
+        const base = window.location.hostname.includes('localhost') ? 'http://localhost:9080' : 'https://api.text-generator.io';
+        const resp = await fetch(`${base}/api/v1/audio-extraction`, {
+            method: 'POST',
+            headers: {'Content-Type':'application/json', ...(secret?{secret}:{})},
+            body: JSON.stringify({audio_url: audioUrl, translate_to_english: translate})
+        });
+        resultEl.textContent = JSON.stringify(await resp.json(), null, 2);
+    });
+    runFileBtn.addEventListener('click', async () => {
+        const file = document.getElementById('audioFile').files[0];
+        const translate = document.getElementById('translate').checked;
+        if (!file) { alert('Choose a file'); return; }
+        const base = window.location.hostname.includes('localhost') ? 'http://localhost:9080' : 'https://api.text-generator.io';
+        const formData = new FormData();
+        formData.append('audio_file', file);
+        formData.append('translate_to_english', translate);
+        const resp = await fetch(`${base}/api/v1/audio-file-extraction`, {
+            method: 'POST',
+            headers: secret ? {secret} : {},
+            body: formData
+        });
+        resultEl.textContent = JSON.stringify(await resp.json(), null, 2);
+    });
+</script>
+</body>
+</html>

--- a/static/templates/speech-to-text.jinja2
+++ b/static/templates/speech-to-text.jinja2
@@ -1,0 +1,24 @@
+{% extends 'templates/base.jinja2' %}
+
+{% block headers %}
+
+    {% set title = 'Speech To Text - Text Generator' -%}
+    {% set description = 'Transcribe audio using affordable Speech To Text.' -%}
+
+    <meta charset="utf-8">
+    <title>{{ title }}</title>
+    <meta name="description" content="{{ description }}">
+    <meta name="keywords" content="speech to text, transcription, API">
+    <meta property="og:title" content="{{ title }}">
+    <meta property="og:url" content="{{ url }}">
+    <meta property="og:image" content="{{ static_url }}/img/brain-generated256.png">
+    <meta property="og:description" content="{{ description }}">
+    <meta property="og:type" content="website">
+    <meta property="og:site_name" content="Text Generator">
+    <meta property="fb:admins" content="337972272904903">
+
+{% endblock %}
+
+{% block mainbody %}
+    {% include "/templates/shared/speech-to-text.jinja2" %}
+{% endblock %}


### PR DESCRIPTION
## Summary
- strip out `adsbygoogle` references from static templates
- add `servers` section to OpenAPI spec so docs use `api.text-generator.io`
- provide new Speech to Text playground page
- link to Speech to Text page from mobile drawer

## Testing
- `pytest -q` *(fails: command not found)*