### PR TITLE
Replace Loguru with std logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -279,3 +279,15 @@ stretch your body every 30 mins with the say command...
 ```shell
 watch -n 1800 'echo "stretch your body" | espeak -s 120'
 ```
+
+## Logging Configuration
+
+All modules now use the standard `logging` package. Logging is configured via
+`questions.logging_config.setup_logging`. The following environment variables can
+control behaviour:
+
+* `LOG_LEVEL` – override the default log level.
+* `COLOR_LOGS` – set to `0` to disable coloured output.
+* `LOG_FILE` – if set, logs will also be written to this file.
+
+`main.py` enables Google Cloud Logging automatically when running on GCP.

--- a/main.py
+++ b/main.py
@@ -11,7 +11,8 @@ from fastapi import Form, HTTPException, Header
 from fastapi import Request
 from fastapi.staticfiles import StaticFiles
 from fastapi.templating import Jinja2Templates
-from loguru import logger
+import logging
+from questions.logging_config import setup_logging
 from starlette.responses import JSONResponse, Response, RedirectResponse
 from starlette.routing import Route
 from starlette.datastructures import URL
@@ -23,6 +24,10 @@ from questions.gameon_utils import GameOnUtils
 from questions.models import CreateUserRequest, GetUserRequest, GenerateParams
 from questions.payments.payments import get_self_hosted_subscription_count_for_user, get_subscription_item_id_for_user_email
 from questions.utils import random_string
+
+# Configure logging to also send logs to Google Cloud
+setup_logging(use_cloud=True)
+logger = logging.getLogger(__name__)
 
 # Import the claude_queries module directly
 from questions.inference_server.claude_queries import query_to_claude_async

--- a/questions/ai_wrapper.py
+++ b/questions/ai_wrapper.py
@@ -1,9 +1,12 @@
 from sellerinfo import CLAUDE_API_KEY
-from loguru import logger
+import logging
+from questions.logging_config import setup_logging
+
+setup_logging()
+logger = logging.getLogger(__name__)
 
 import aiohttp
 from sellerinfo import CLAUDE_API_KEY
-from loguru import logger
 
 async def generate_with_claude(prompt, prefill="", retries=3):
     api_key = CLAUDE_API_KEY

--- a/questions/audio_server/audio_server.py
+++ b/questions/audio_server/audio_server.py
@@ -10,7 +10,11 @@ from fastapi import BackgroundTasks
 from fastapi import Request, Header
 from fastapi.staticfiles import StaticFiles
 from fastapi.templating import Jinja2Templates
-from loguru import logger
+import logging
+from questions.logging_config import setup_logging
+
+setup_logging()
+logger = logging.getLogger(__name__)
 from starlette.responses import JSONResponse, Response
 
 from questions.audio_server.audio_dl import request_get

--- a/questions/audio_server/reqs-now.txt
+++ b/questions/audio_server/reqs-now.txt
@@ -64,7 +64,6 @@ Jinja2==3.1.1
 joblib==1.1.0
 kiwisolver==1.4.4
 lazy-object-proxy==1.4.3
-loguru==0.5.3
 lxml==4.9.1
 Markdown==3.4.1
 MarkupSafe==2.1.1

--- a/questions/bert_embed.py
+++ b/questions/bert_embed.py
@@ -4,7 +4,11 @@ import torch
 
 from questions.perplexity import DEVICE
 from questions.utils import log_time
-from loguru import logger
+import logging
+from questions.logging_config import setup_logging
+
+setup_logging()
+logger = logging.getLogger(__name__)
 
 class FeatureExtractModel(nn.Module):
     def __init__(self, checkpoint, freeze=False, device="cuda"):

--- a/questions/download_utils.py
+++ b/questions/download_utils.py
@@ -1,7 +1,11 @@
 from pathlib import Path
 
 from google.cloud import storage
-from loguru import logger
+import logging
+from questions.logging_config import setup_logging
+
+setup_logging(use_cloud=True)
+logger = logging.getLogger(__name__)
 
 from questions.utils import log_time
 

--- a/questions/inference_server/inference_server.py
+++ b/questions/inference_server/inference_server.py
@@ -11,7 +11,11 @@ from fastapi import BackgroundTasks, UploadFile, File, Form
 from fastapi import Request, Header
 from fastapi.staticfiles import StaticFiles
 from fastapi.templating import Jinja2Templates
-from loguru import logger
+import logging
+from questions.logging_config import setup_logging
+
+setup_logging()
+logger = logging.getLogger(__name__)
 from starlette.responses import JSONResponse, RedirectResponse, Response, StreamingResponse, HTMLResponse
 
 from questions.audio_server.audio_dl import request_get

--- a/questions/inference_server/model_cache.py
+++ b/questions/inference_server/model_cache.py
@@ -8,7 +8,11 @@ import os
 import gc
 
 import torch.cuda
-from loguru import logger
+import logging
+from questions.logging_config import setup_logging
+
+setup_logging()
+logger = logging.getLogger(__name__)
 
 DEVICE = "cuda" if torch.cuda.is_available() else "cpu"
 

--- a/questions/inference_server/ofa-requirements.txt
+++ b/questions/inference_server/ofa-requirements.txt
@@ -28,7 +28,6 @@ google-cloud-storage==2.3.0 #not on gae python
 #google-cloud-storage==2.0.0
 
 google-cloud-ndb==1.11.1
-loguru==0.5.3
 pydantic==1.9.0
 jinja2==3.1.1 #not on gae python
 #jinja2==3.0.3

--- a/questions/inference_server/requirements.in
+++ b/questions/inference_server/requirements.in
@@ -39,7 +39,6 @@ google-api-core>=2.0.0
 google-cloud-storage>=2.0.0
 
 google-cloud-ndb>=2.3.0
-loguru>=0.7.0
 jinja2>=3.0.0
 
 nltk>=3.8.0
@@ -67,7 +66,6 @@ numpy>=1.26.0,<2
 pandas>=2.2.3
 python-dateutil>=2.9.0.post0
 youtube_dl
-loguru
 # end OFA
 
 # OCR/pdf processing

--- a/questions/inference_server/requirements.txt
+++ b/questions/inference_server/requirements.txt
@@ -257,7 +257,6 @@ lightning-utilities==0.11.8
     #   torchmetrics
 llvmlite==0.43.0
     # via numba
-loguru==0.7.3
     # via -r requirements.in
 lxml==5.3.0
     # via clldutils

--- a/questions/link_enricher.py
+++ b/questions/link_enricher.py
@@ -9,7 +9,11 @@ import bs4
 import cachetools
 from PIL import Image
 from cachetools import cached
-from loguru import logger
+import logging
+from questions.logging_config import setup_logging
+
+setup_logging()
+logger = logging.getLogger(__name__)
 from requests_futures.sessions import FuturesSession
 import torch
 from transformers import AutoModelForCausalLM, AutoTokenizer

--- a/questions/logging_config.py
+++ b/questions/logging_config.py
@@ -1,0 +1,63 @@
+import logging
+import os
+import sys
+
+from colorama import Fore, Style, init as colorama_init
+
+colorama_init()
+
+LEVEL_COLORS = {
+    logging.DEBUG: Fore.CYAN,
+    logging.INFO: Fore.GREEN,
+    logging.WARNING: Fore.YELLOW,
+    logging.ERROR: Fore.RED,
+    logging.CRITICAL: Fore.MAGENTA,
+}
+
+class ColorFormatter(logging.Formatter):
+    def format(self, record: logging.LogRecord) -> str:
+        level_color = LEVEL_COLORS.get(record.levelno, '')
+        record.levelname = f"{level_color}{record.levelname}{Style.RESET_ALL}"
+        return super().format(record)
+
+def setup_logging(level: int = logging.INFO, use_cloud: bool = False) -> None:
+    """Configure root logger.
+
+    Environment variables:
+        LOG_LEVEL: Override log level (e.g. "DEBUG").
+        COLOR_LOGS: Set to "0" to disable color output.
+        LOG_FILE: If set, also log to this file.
+    """
+    env_level = os.environ.get("LOG_LEVEL")
+    if env_level:
+        level = logging.getLevelName(env_level.upper())  # type: ignore[arg-type]
+
+    root_logger = logging.getLogger()
+    if root_logger.handlers:
+        return
+    root_logger.setLevel(level)
+    use_color = os.environ.get("COLOR_LOGS", "1") != "0"
+    fmt = '%(asctime)s [%(levelname)s] %(name)s:%(funcName)s:%(lineno)d - %(message)s'
+    formatter_cls = ColorFormatter if use_color else logging.Formatter
+    formatter = formatter_cls(fmt, '%Y-%m-%d %H:%M:%S')
+
+    handler = logging.StreamHandler(sys.stdout)
+    handler.setFormatter(formatter)
+    root_logger.addHandler(handler)
+
+    log_file = os.environ.get("LOG_FILE")
+    if log_file:
+        file_handler = logging.FileHandler(log_file)
+        file_handler.setFormatter(formatter)
+        root_logger.addHandler(file_handler)
+
+    if use_cloud:
+        try:
+            import google.cloud.logging  # type: ignore
+            client = google.cloud.logging.Client()
+            cloud_handler = client.get_default_handler()
+            cloud_handler.setFormatter(formatter)
+            root_logger.addHandler(cloud_handler)
+            client.setup_logging(log_level=level)
+        except Exception as e:  # pragma: no cover - environment may lack gcloud
+            root_logger.error("Failed to initialize Google Cloud Logging: %s", e)

--- a/questions/payments/payments.py
+++ b/questions/payments/payments.py
@@ -4,7 +4,11 @@ from pathlib import Path
 import cachetools
 import stripe
 from cachetools import cached
-from loguru import logger
+import logging
+from questions.logging_config import setup_logging
+
+setup_logging(use_cloud=True)
+logger = logging.getLogger(__name__)
 
 import stripe
 

--- a/questions/summarization.py
+++ b/questions/summarization.py
@@ -1,7 +1,11 @@
 import torch
 from nltk import sent_tokenize
 from transformers import pipeline
-from loguru import logger
+import logging
+from questions.logging_config import setup_logging
+
+setup_logging()
+logger = logging.getLogger(__name__)
 
 from questions.inference_server.model_cache import DEVICE
 from questions.utils import log_time

--- a/questions/test_inf_moon.py
+++ b/questions/test_inf_moon.py
@@ -2,7 +2,11 @@ import pytest
 from transformers import AutoModelForCausalLM, AutoTokenizer
 from PIL import Image
 import os
-from loguru import logger
+import logging
+from questions.logging_config import setup_logging
+
+setup_logging()
+logger = logging.getLogger(__name__)
 
 def test_moondream():
     model_id = "vikhyatk/moondream2"

--- a/questions/text_generator_inference.py
+++ b/questions/text_generator_inference.py
@@ -7,7 +7,11 @@ from typing import Dict, List
 from accelerate import Accelerator, infer_auto_device_map, dispatch_model
 # from accelerate.utils import is_tpu_available
 from cachetools import TTLCache
-from loguru import logger
+import logging
+from questions.logging_config import setup_logging
+
+setup_logging()
+logger = logging.getLogger(__name__)
 from transformers import (
     GPT2TokenizerFast,
     GPTNeoForCausalLM,

--- a/questions/tools/domain_availability_checker.py
+++ b/questions/tools/domain_availability_checker.py
@@ -1,6 +1,10 @@
 import gradio as gr
 import subprocess
-from loguru import logger
+import logging
+from questions.logging_config import setup_logging
+
+setup_logging()
+logger = logging.getLogger(__name__)
 import requests
 import re
 import asyncio

--- a/questions/utils.py
+++ b/questions/utils.py
@@ -9,7 +9,11 @@ from datetime import datetime
 from datetime import timedelta
 from pathlib import Path
 
-from loguru import logger
+import logging
+from questions.logging_config import setup_logging
+
+setup_logging()
+logger = logging.getLogger(__name__)
 
 debug = (
     os.environ.get("SERVER_SOFTWARE", "").startswith("Development")

--- a/reqs-all.txt
+++ b/reqs-all.txt
@@ -64,7 +64,6 @@ Jinja2==3.1.1
 joblib==1.1.0
 kiwisolver==1.4.4
 lazy-object-proxy==1.4.3
-loguru==0.5.3
 lxml==4.9.1
 Markdown==3.4.1
 MarkupSafe==2.1.1

--- a/requirements.in
+++ b/requirements.in
@@ -24,7 +24,6 @@ google-api-core
 google-cloud-storage
 
 google-cloud-ndb
-loguru
 #jinja2
 jinja2
 websockets

--- a/requirements.txt
+++ b/requirements.txt
@@ -105,7 +105,6 @@ lazy-object-proxy==1.4.3
     # via
     #   -r requirements.in
     #   astroid
-loguru==0.5.3
     # via -r requirements.in
 markupsafe==3.0.2
     # via jinja2

--- a/routes/documents.py
+++ b/routes/documents.py
@@ -1,6 +1,10 @@
 from fastapi import APIRouter, Request, HTTPException
 from starlette.responses import JSONResponse
-from loguru import logger
+import logging
+from questions.logging_config import setup_logging
+
+setup_logging()
+logger = logging.getLogger(__name__)
 
 # Assuming models are accessible like this, adjust if necessary
 from questions.db_models import Document, User 

--- a/scripts/monitorer.py
+++ b/scripts/monitorer.py
@@ -1,6 +1,10 @@
 import subprocess
 from time import sleep
-from loguru import logger
+import logging
+from questions.logging_config import setup_logging
+
+setup_logging()
+logger = logging.getLogger(__name__)
 import requests
 
 

--- a/scripts/onnx_compile.py
+++ b/scripts/onnx_compile.py
@@ -9,7 +9,11 @@ from onnxruntime import InferenceSession
 import numpy as np
 import os
 import subprocess
-from loguru import logger
+import logging
+from questions.logging_config import setup_logging
+
+setup_logging()
+logger = logging.getLogger(__name__)
 
 if not os.path.exists("models/neo-causal-lm"):
     try:

--- a/scripts/use_case_generator.py
+++ b/scripts/use_case_generator.py
@@ -2,7 +2,11 @@ import json
 import os
 
 import requests
-from loguru import logger
+import logging
+from questions.logging_config import setup_logging
+
+setup_logging()
+logger = logging.getLogger(__name__)
 
 from use_cases_to_generate import use_cases
 from scripts.openai_examples import openai_examples_map

--- a/scripts/use_case_generator2.py
+++ b/scripts/use_case_generator2.py
@@ -2,7 +2,11 @@ import json
 import os
 
 import requests
-from loguru import logger
+import logging
+from questions.logging_config import setup_logging
+
+setup_logging()
+logger = logging.getLogger(__name__)
 
 use_cases = {
     "fantasy-writing": {

--- a/scripts/use_case_long_description_generator.py
+++ b/scripts/use_case_long_description_generator.py
@@ -1,7 +1,11 @@
 import json
 import os
 import requests
-from loguru import logger
+import logging
+from questions.logging_config import setup_logging
+
+setup_logging()
+logger = logging.getLogger(__name__)
 
 from questions.usecase_fixtures import use_cases
 

--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,6 @@ def setup_package():
             'google-api-python-client==2.43.0',
             'google-api-core==1.31.5',
             'google-cloud-storage==2.3.0',
-            'loguru==0.5.3',
             'pydantic==1.9.0',
             'jinja2==3.1.1',
             'nltk==3.7.0',

--- a/static/templates/shared/embed-images-text-and-code.jinja2
+++ b/static/templates/shared/embed-images-text-and-code.jinja2
@@ -21,7 +21,7 @@
 <h4>Python code to embed text/code and images</h4>
 
             <pre><code id="code-snippet-embed" class="language-python">import requests
-from loguru import logger
+import logging
 import os
 import pickle
 

--- a/tests/performance/test_e2e_perf.py
+++ b/tests/performance/test_e2e_perf.py
@@ -2,7 +2,11 @@ import traceback
 
 import pytest
 import requests
-from loguru import logger
+import logging
+from questions.logging_config import setup_logging
+
+setup_logging()
+logger = logging.getLogger(__name__)
 
 from questions.utils import log_time
 from requests_futures.sessions import FuturesSession

--- a/tests/unit/questions/test_link_enricher.py
+++ b/tests/unit/questions/test_link_enricher.py
@@ -1,5 +1,9 @@
 from questions.link_enricher import get_urls, enrich_links
-from loguru import logger
+import logging
+from questions.logging_config import setup_logging
+
+setup_logging()
+logger = logging.getLogger(__name__)
 
 
 def test_get_urls():

--- a/tests/unit/test_perplexity.py
+++ b/tests/unit/test_perplexity.py
@@ -1,5 +1,9 @@
 from transformers import GPT2LMHeadModel, GPT2Tokenizer, GPT2TokenizerFast, BloomTokenizerFast, BloomForCausalLM
-from loguru import logger
+import logging
+from questions.logging_config import setup_logging
+
+setup_logging()
+logger = logging.getLogger(__name__)
 
 import torch
 


### PR DESCRIPTION
## Summary
- replace loguru with Python's `logging` throughout
- add colored logging with optional Google Cloud integration
- make logging level, colors, and log file configurable via env vars
- document logging configuration in README

## Testing
- `pip install -r requirements-test.txt`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sellerinfo')*

------
https://chatgpt.com/codex/tasks/task_e_68422e868c5c83338a69072a8860799c