### PR TITLE
Extract TTS helpers with tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Install dependencies
         run: uv pip install --system -r requirements.txt -r requirements-test.txt
       - name: Ruff
-        run: ruff .
+        run: ruff check .
       - name: Run unit tests
         run: pytest --cov=questions --cov-report=xml -q
       - name: Upload coverage

--- a/questions/inference_server/tts_utils.py
+++ b/questions/inference_server/tts_utils.py
@@ -1,0 +1,66 @@
+import numpy as np
+from typing import Callable, Iterator, Tuple, List
+
+
+def srt_format_timestamp(seconds: float) -> str:
+    """Format seconds to SRT timestamp."""
+    if seconds < 0:
+        raise ValueError("non-negative timestamp expected")
+    milliseconds = round(seconds * 1000.0)
+
+    hours = milliseconds // 3_600_000
+    milliseconds -= hours * 3_600_000
+
+    minutes = milliseconds // 60_000
+    milliseconds -= minutes * 60_000
+
+    sec = milliseconds // 1_000
+    milliseconds -= sec * 1_000
+
+    return f"{hours}:{minutes:02d}:{sec:02d},{milliseconds:03d}"
+
+
+def write_srt(transcript: Iterator[dict]) -> str:
+    """Return a simple SRT string from whisper-like transcript segments."""
+    count = 0
+    srt = []
+    for segment in transcript:
+        count += 1
+        srt.append(
+            f"{count}\n"
+            f"{srt_format_timestamp(segment['start'])} --> {srt_format_timestamp(segment['end'])}\n"
+            f"{segment['text'].replace('-->', '->').strip()}\n"
+        )
+    return "\n".join(srt)
+
+
+def chunk_text_words(text: str, chunk_words: int) -> List[str]:
+    """Split *text* into chunks of at most *chunk_words* words."""
+    if chunk_words <= 0:
+        raise ValueError("chunk_words must be positive")
+    words = text.split()
+    return [" ".join(words[i : i + chunk_words]) for i in range(0, len(words), chunk_words)]
+
+
+def synthesize_full_text(
+    text: str,
+    voice: str = "af_nicole",
+    speed: float = 1.0,
+    chunk_words: int = 100,
+    process_fn: Callable[[str, str, float], Tuple[int, np.ndarray]] | None = None,
+    sample_rate: int = 24000,
+) -> Tuple[int, np.ndarray]:
+    """Generate speech for arbitrarily long text by chunking."""
+    if process_fn is None:
+        from .inference_server import audio_process as process_fn  # local import to avoid cycles
+
+    if not text.strip():
+        return (sample_rate, np.zeros(0, dtype=np.int16))
+
+    segments = []
+    for chunk in chunk_text_words(text, chunk_words):
+        _, audio = process_fn(chunk, voice=voice, speed=speed)
+        segments.append(audio)
+
+    full_audio = np.concatenate(segments) if segments else np.zeros(0, dtype=np.int16)
+    return (sample_rate, full_audio)

--- a/tests/unit/test_kokoro_utils.py
+++ b/tests/unit/test_kokoro_utils.py
@@ -1,0 +1,29 @@
+import types
+from pathlib import Path
+import re
+
+# Load only the text-normalization helpers from kokoro.py to avoid heavy deps
+lines = Path('questions/inference_server/kokoro.py').read_text().splitlines()
+code = "\n".join([l for l in lines[1:73] if 'phonemizer' not in l and 'torch' not in l])
+mod = types.ModuleType('kokoro_utils')
+exec(code, mod.__dict__)
+
+
+def test_split_num_year():
+    match = re.match(r"\d+", "2023")
+    assert mod.split_num(match) == "20 23"
+
+
+def test_split_num_time():
+    match = re.match(r"[0-9:]+", "12:05")
+    assert mod.split_num(match) == "12 oh 5"
+
+
+def test_flip_money_dollars():
+    match = re.match(r"[$£]\d+(?:\.\d+)?", "$2.50")
+    assert mod.flip_money(match) == "2 dollars and 50 cents"
+
+
+def test_point_num_simple():
+    match = re.match(r"\d*\.\d+", "3.14")
+    assert mod.point_num(match) == "3 point 1 4"

--- a/tests/unit/test_synthesize_full_text.py
+++ b/tests/unit/test_synthesize_full_text.py
@@ -1,0 +1,14 @@
+import numpy as np
+
+from questions.inference_server.tts_utils import synthesize_full_text
+
+
+def test_synthesize_full_text_chunks():
+    rate, audio = synthesize_full_text(
+        "a b c d e f",
+        chunk_words=2,
+        process_fn=lambda chunk, voice="af", speed=1.0: (16000, np.array([1], dtype=np.int16)),
+        sample_rate=16000,
+    )
+    assert rate == 16000
+    assert len(audio) == 3

--- a/tests/unit/test_tts_utils.py
+++ b/tests/unit/test_tts_utils.py
@@ -1,0 +1,30 @@
+import numpy as np
+import pytest
+from questions.inference_server import tts_utils
+
+
+def test_srt_format_timestamp_simple():
+    assert tts_utils.srt_format_timestamp(1.234) == "0:00:01,234"
+
+
+def test_write_srt_basic():
+    transcript = [
+        {"start": 0.0, "end": 1.0, "text": "hello"},
+        {"start": 1.0, "end": 2.0, "text": "world"},
+    ]
+    result = tts_utils.write_srt(transcript)
+    assert "1\n0:00:00,000 --> 0:00:01,000\nhello" in result
+    assert "2\n0:00:01,000 --> 0:00:02,000\nworld" in result
+
+def test_chunk_text_words():
+    result = tts_utils.chunk_text_words("a b c d e", 2)
+    assert result == ["a b", "c d", "e"]
+
+def test_chunk_text_words_invalid():
+    with pytest.raises(ValueError):
+        tts_utils.chunk_text_words("text", 0)
+
+
+def test_srt_format_timestamp_negative():
+    with pytest.raises(ValueError):
+        tts_utils.srt_format_timestamp(-1)


### PR DESCRIPTION
## Summary
- move `srt_format_timestamp`, `write_srt`, and `synthesize_full_text` into new `tts_utils` module
- simplify and extend unit tests to import the new helpers
- add helper `chunk_text_words` and expose sample rate option for easy testing
- improve validation for timestamps and chunk sizes

## Testing
- `pytest -q`
- `ruff check .` *(fails: unused imports in gameon/facebook.py)*

------
https://chatgpt.com/codex/tasks/task_e_68439f6f14f88333b818156d4dcc7f03