### PR TITLE
Remove Python 3.11 from CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.11', '3.12']
+        python-version: ['3.12']
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5


### PR DESCRIPTION
## Summary
- remove Python 3.11 from the CI test matrix

## Testing
- `ruff check .` *(fails: `cgi` and `time` unused in `gameon/facebook.py`)*
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6843a64af0a48333b8f117d0764f48b0