### PR TITLE
Add docx/ppt/pdf markdown conversion

### DIFF
--- a/questions/document_processor.py
+++ b/questions/document_processor.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+from typing import Iterable, Dict
+from markitdown import MarkItDown
+import asyncio
+
+_converter = MarkItDown()
+
+
+def convert_to_markdown(source: str) -> str:
+    """Convert a local file or URL to Markdown using MarkItDown."""
+    if source.startswith(("http://", "https://")):
+        result = _converter.convert_url(source)
+    else:
+        result = _converter.convert_local(source)
+    return result.markdown
+
+
+async def convert_documents_async(sources: Iterable[str]) -> Dict[str, str]:
+    """Convert multiple documents concurrently to Markdown."""
+    loop = asyncio.get_event_loop()
+    tasks = {s: loop.run_in_executor(None, convert_to_markdown, s) for s in sources}
+    results = {}
+    for src, task in tasks.items():
+        results[src] = await task
+    return results

--- a/questions/tools/document_markdown_cli.py
+++ b/questions/tools/document_markdown_cli.py
@@ -1,0 +1,17 @@
+import click
+from questions.document_processor import convert_to_markdown
+
+@click.command()
+@click.argument('source')
+@click.option('-o', '--output', type=click.Path(), help='Output markdown file')
+def main(source: str, output: str | None):
+    """Convert DOCX/PPTX/PDF file or URL to Markdown."""
+    markdown = convert_to_markdown(source)
+    if output:
+        with open(output, 'w', encoding='utf-8') as f:
+            f.write(markdown)
+    else:
+        click.echo(markdown)
+
+if __name__ == '__main__':
+    main()

--- a/requirements.in
+++ b/requirements.in
@@ -50,3 +50,4 @@ httpx
 httpcore
 pillow
 pyppeteer
+markitdown[all]==0.1.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,8 +9,22 @@ anyio==4.7.0
     #   anthropic
     #   httpx
     #   starlette
+appdirs==1.4.4
+    # via pyppeteer
 astroid==2.3.3
     # via -r requirements.in
+azure-ai-documentintelligence==1.0.2
+    # via markitdown
+azure-core==1.34.0
+    # via
+    #   azure-ai-documentintelligence
+    #   azure-identity
+azure-identity==1.23.0
+    # via markitdown
+beautifulsoup4==4.13.4
+    # via
+    #   markdownify
+    #   markitdown
 cachetools==4.2.4
     # via
     #   -r requirements.in
@@ -19,20 +33,45 @@ certifi==2024.8.30
     # via
     #   httpcore
     #   httpx
+    #   pyppeteer
     #   requests
+cffi==1.17.1
+    # via cryptography
 charset-normalizer==3.4.0
-    # via requests
-click==7.0
+    # via
+    #   markitdown
+    #   pdfminer-six
+    #   requests
+click==8.2.1
     # via
     #   -r requirements.in
+    #   magika
     #   nltk
     #   uvicorn
+cobble==0.1.4
+    # via mammoth
 colorama==0.4.3
     # via -r requirements.in
+coloredlogs==15.0.1
+    # via onnxruntime
+cryptography==45.0.3
+    # via
+    #   azure-identity
+    #   msal
+    #   pdfminer-six
+    #   pyjwt
+defusedxml==0.7.1
+    # via
+    #   markitdown
+    #   youtube-transcript-api
 distro==1.9.0
     # via anthropic
+et-xmlfile==2.0.0
+    # via openpyxl
 fastapi==0.115.12
     # via -r requirements.in
+flatbuffers==25.2.10
+    # via onnxruntime
 google-api-core==1.31.5
     # via
     #   -r requirements.in
@@ -88,11 +127,17 @@ httpx==0.28.1
     # via
     #   -r requirements.in
     #   anthropic
+humanfriendly==10.0
+    # via coloredlogs
 idna==3.10
     # via
     #   anyio
     #   httpx
     #   requests
+importlib-metadata==8.7.0
+    # via pyppeteer
+isodate==0.7.2
+    # via azure-ai-documentintelligence
 isort==4.3.21
     # via -r requirements.in
 jinja2==3.1.4
@@ -105,27 +150,70 @@ lazy-object-proxy==1.4.3
     # via
     #   -r requirements.in
     #   astroid
+lxml==5.4.0
+    # via
+    #   markitdown
+    #   python-pptx
+magika==0.6.2
+    # via markitdown
+mammoth==1.9.1
+    # via markitdown
+markdownify==1.1.0
+    # via markitdown
+markitdown==0.1.2
     # via -r requirements.in
 markupsafe==3.0.2
     # via jinja2
 mccabe==0.6.1
     # via -r requirements.in
+mpmath==1.3.0
+    # via sympy
+msal==1.32.3
+    # via
+    #   azure-identity
+    #   msal-extensions
+msal-extensions==1.3.1
+    # via azure-identity
 nltk==3.6.7
     # via -r requirements.in
+numpy==2.2.6
+    # via
+    #   magika
+    #   onnxruntime
+    #   pandas
+olefile==0.47
+    # via markitdown
+onnxruntime==1.22.0
+    # via magika
+openpyxl==3.1.5
+    # via markitdown
 packaging==24.2
-    # via google-api-core
+    # via
+    #   google-api-core
+    #   onnxruntime
+pandas==2.3.0
+    # via markitdown
+pdfminer-six==20250506
+    # via markitdown
+pillow==10.3.0
+    # via
+    #   -r requirements.in
+    #   python-pptx
 protobuf==3.20.0
     # via
     #   -r requirements.in
     #   google-api-core
     #   google-cloud-storage
     #   googleapis-common-protos
+    #   onnxruntime
 pyasn1==0.6.1
     # via
     #   pyasn1-modules
     #   rsa
 pyasn1-modules==0.4.1
     # via google-auth
+pycparser==2.22
+    # via cffi
 pydantic==2.11.3
     # via
     #   -r requirements.in
@@ -133,25 +221,44 @@ pydantic==2.11.3
     #   fastapi
 pydantic-core==2.33.1
     # via pydantic
+pydub==0.25.1
+    # via markitdown
+pyee==8.2.2
+    # via pyppeteer
+pyjwt==2.10.1
+    # via msal
 pymemcache==4.0.0
     # via google-cloud-ndb
 pyparsing==3.2.0
     # via httplib2
+pyppeteer==1.0.2
+    # via -r requirements.in
+python-dateutil==2.9.0.post0
+    # via pandas
+python-dotenv==1.1.0
+    # via magika
 python-multipart==0.0.5
     # via -r requirements.in
+python-pptx==1.0.2
+    # via markitdown
 pytz==2024.2
     # via
     #   google-api-core
     #   google-cloud-ndb
+    #   pandas
 redis==5.2.1
     # via google-cloud-ndb
 regex==2024.11.6
     # via nltk
 requests==2.32.3
     # via
+    #   azure-core
     #   google-api-core
     #   google-cloud-storage
+    #   markitdown
+    #   msal
     #   stripe
+    #   youtube-transcript-api
 rsa==4.9
     # via
     #   -r requirements.in
@@ -165,42 +272,70 @@ six==1.17.0
     # via
     #   -r requirements.in
     #   astroid
+    #   azure-core
     #   google-api-core
     #   google-auth
+    #   markdownify
+    #   python-dateutil
     #   python-multipart
 sniffio==1.3.1
     # via
     #   anthropic
     #   anyio
+soupsieve==2.7
+    # via beautifulsoup4
+speechrecognition==3.14.3
+    # via markitdown
 starlette==0.46.2
     # via fastapi
 stripe==3.4.0
     # via -r requirements.in
+sympy==1.14.0
+    # via onnxruntime
 tqdm==4.67.1
-    # via nltk
+    # via
+    #   nltk
+    #   pyppeteer
 typing-extensions==4.12.2
     # via
     #   anthropic
     #   anyio
+    #   azure-ai-documentintelligence
+    #   azure-core
+    #   azure-identity
+    #   beautifulsoup4
     #   fastapi
     #   pydantic
     #   pydantic-core
+    #   python-pptx
+    #   speechrecognition
     #   typing-inspection
 typing-inspection==0.4.0
     # via pydantic
+tzdata==2025.2
+    # via pandas
 uritemplate==4.1.1
     # via google-api-python-client
-urllib3<2
-    # via requests
+urllib3==1.26.20
+    # via
+    #   -r requirements.in
+    #   pyppeteer
+    #   requests
 uvicorn==0.34.2
     # via -r requirements.in
 websockets==10.4
-    # via -r requirements.in
+    # via
+    #   -r requirements.in
+    #   pyppeteer
 wrapt==1.11.2
     # via
     #   -r requirements.in
     #   astroid
-pillow==10.3.0
-    # via -r requirements.in
-pyppeteer==1.0.2
-    # via -r requirements.in
+xlrd==2.0.1
+    # via markitdown
+xlsxwriter==3.2.3
+    # via python-pptx
+youtube-transcript-api==1.0.3
+    # via markitdown
+zipp==3.22.0
+    # via importlib-metadata

--- a/tests/unit/test_document_cli.py
+++ b/tests/unit/test_document_cli.py
@@ -1,0 +1,31 @@
+from click.testing import CliRunner
+import requests
+import pytest
+
+from questions.tools.document_markdown_cli import main
+
+pytestmark = [pytest.mark.integration, pytest.mark.internet]
+
+DOCX_URL = "https://calibre-ebook.com/downloads/demos/demo.docx"
+
+
+def download(url, path):
+    resp = requests.get(url, timeout=30)
+    resp.raise_for_status()
+    with open(path, "wb") as f:
+        f.write(resp.content)
+
+
+@pytest.fixture(scope="session")
+def docx_file(tmp_path_factory):
+    path = tmp_path_factory.mktemp("docs") / "cli.docx"
+    download(DOCX_URL, path)
+    return path
+
+
+def test_cli_output_file(docx_file, tmp_path):
+    runner = CliRunner()
+    output_file = tmp_path / "out.md"
+    result = runner.invoke(main, [str(docx_file), "-o", str(output_file)])
+    assert result.exit_code == 0
+    assert output_file.read_text().strip()

--- a/tests/unit/test_document_processor.py
+++ b/tests/unit/test_document_processor.py
@@ -1,0 +1,65 @@
+import requests
+import pytest
+
+from questions.document_processor import convert_to_markdown, convert_documents_async
+
+pytestmark = [pytest.mark.integration, pytest.mark.internet]
+
+DOCX_URL = "https://calibre-ebook.com/downloads/demos/demo.docx"
+PPTX_URL = "https://filesamples.com/samples/document/pptx/sample3.pptx"
+PDF_URL = "https://github.com/mozilla/pdf.js/raw/master/web/compressed.tracemonkey-pldi-09.pdf"
+
+
+def download(url, path):
+    resp = requests.get(url, timeout=30)
+    resp.raise_for_status()
+    with open(path, "wb") as f:
+        f.write(resp.content)
+
+
+@pytest.fixture(scope="session")
+def docx_file(tmp_path_factory):
+    from docx import Document
+    path = tmp_path_factory.mktemp("docs") / "sample.docx"
+    doc = Document()
+    doc.add_paragraph("Hello World")
+    doc.save(path)
+    return path
+
+@pytest.fixture(scope="session")
+def pptx_file(tmp_path_factory):
+    from pptx import Presentation
+    path = tmp_path_factory.mktemp("docs") / "sample.pptx"
+    prs = Presentation()
+    prs.slides.add_slide(prs.slide_layouts[0])
+    prs.save(path)
+    return path
+
+@pytest.fixture(scope="session")
+def pdf_file(tmp_path_factory):
+    path = tmp_path_factory.mktemp("docs") / "sample.pdf"
+    download(PDF_URL, path)
+    return path
+
+
+def test_docx_local(docx_file):
+    md = convert_to_markdown(str(docx_file))
+    assert md.strip()
+
+
+def test_pptx_local(pptx_file):
+    md = convert_to_markdown(str(pptx_file))
+    assert md.strip()
+
+
+def test_pdf_local(pdf_file):
+    md = convert_to_markdown(str(pdf_file))
+    assert md.strip()
+
+
+@pytest.mark.asyncio
+async def test_convert_documents_async(docx_file, pptx_file):
+    results = await convert_documents_async([str(docx_file), str(pptx_file)])
+    assert len(results) == 2
+    for text in results.values():
+        assert text.strip()


### PR DESCRIPTION
## Summary
- add `document_processor` with markitdown-based conversion
- add CLI `document_markdown_cli.py`
- support async batch conversion
- create tests for converting docx/ppt/pdf and the CLI
- update requirements to include `markitdown[all]`

## Testing
- `ruff check questions/document_processor.py tests/unit/test_document_processor.py tests/unit/test_document_cli.py`
- `pytest tests/unit/test_document_processor.py tests/unit/test_document_cli.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6843d5f4e7108333bd14028c507d3183