### PR TITLE
Add SmolLM3 demo and constants

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ make download-punkt   # download the punkt dataset for NLTK
 Download models from huggingface.
 
 ```shell
-huggingface-cli download HuggingFaceTB/SmolLM2-1.7B-Instruct --local-dir models/SmolLM-1.7B
+huggingface-cli download HuggingFaceTB/SmolLM3-3B --local-dir models/SmolLM3-3B
 wget -P models https://huggingface.co/geneing/Kokoro/resolve/f610f07c62f8baa30d4ed731530e490230e4ee83/kokoro-v0_19.pth
 
 ```

--- a/questions/constants.py
+++ b/questions/constants.py
@@ -1,4 +1,7 @@
 import os
-weights_path_tgz = os.getenv("WEIGHTS_PATH_TGZ", "models/SmolLM-1.7B")
-weights_path_tgc = os.getenv("WEIGHTS_PATH_TGC", "models/SmolLM-1.7B")
-weights_path_tg = os.getenv("WEIGHTS_PATH", "models/SmolLM-1.7B")
+# Default local paths for the SmolLM3 model family. These paths can be
+# overridden with the respective environment variables if a different
+# location is desired.
+weights_path_tgz = os.getenv("WEIGHTS_PATH_TGZ", "models/SmolLM3-3B")
+weights_path_tgc = os.getenv("WEIGHTS_PATH_TGC", "models/SmolLM3-3B")
+weights_path_tg = os.getenv("WEIGHTS_PATH", "models/SmolLM3-3B")

--- a/scripts/example_smollm3.py
+++ b/scripts/example_smollm3.py
@@ -1,0 +1,26 @@
+from transformers import AutoModelForCausalLM, AutoTokenizer
+import torch
+
+
+def main():
+    """Run a simple prompt using the SmolLM3 model."""
+    model_name = "HuggingFaceTB/SmolLM3-3B"
+    device = "cuda" if torch.cuda.is_available() else "cpu"
+
+    tokenizer = AutoTokenizer.from_pretrained(model_name)
+    model = AutoModelForCausalLM.from_pretrained(model_name).to(device)
+
+    prompt = "Give me a brief explanation of gravity in simple terms."
+    messages = [{"role": "user", "content": prompt}]
+    text = tokenizer.apply_chat_template(messages, tokenize=False, add_generation_prompt=True)
+    model_inputs = tokenizer([text], return_tensors="pt").to(device)
+
+    generated_ids = model.generate(**model_inputs, max_new_tokens=128)
+    output_ids = generated_ids[0][len(model_inputs.input_ids[0]):]
+    print(tokenizer.decode(output_ids, skip_special_tokens=True))
+
+
+
+if __name__ == "__main__":
+    main()
+

--- a/tests/unit/test_smollm3_script.py
+++ b/tests/unit/test_smollm3_script.py
@@ -1,0 +1,20 @@
+from unittest import mock
+
+from scripts import example_smollm3
+
+
+def test_example_smollm3(monkeypatch):
+    fake_tokenizer = mock.MagicMock()
+    fake_model = mock.MagicMock()
+    fake_tokenizer.apply_chat_template.return_value = "prompt"
+    fake_inputs = mock.MagicMock()
+    fake_inputs.to.return_value = {"input_ids": [[0, 1]]}
+    fake_tokenizer.__call__ = mock.MagicMock(return_value=fake_inputs)
+    fake_model.generate.return_value = [[0, 1, 2]]
+    fake_model.to.return_value = fake_model
+
+    monkeypatch.setattr(example_smollm3, "AutoTokenizer", mock.MagicMock(from_pretrained=mock.MagicMock(return_value=fake_tokenizer)))
+    monkeypatch.setattr(example_smollm3, "AutoModelForCausalLM", mock.MagicMock(from_pretrained=mock.MagicMock(return_value=fake_model)))
+
+    example_smollm3.main()
+    fake_model.generate.assert_called_once()


### PR DESCRIPTION
## Summary
- update default model paths to SmolLM3
- document new SmolLM3 download command
- add demo script using SmolLM3
- test the demo script with mocking

## Testing
- `pytest -q tests/unit/test_smollm3_script.py`

------
https://chatgpt.com/codex/tasks/task_e_686d922114d48333afd91ba3696b35ff