### PR TITLE
Add speech-to-text demo route

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,6 +218,18 @@ PYTHONPATH=$(pwd):$(pwd)/OFA GOOGLE_APPLICATION_CREDENTIALS=secrets/google-crede
 PYTHONPATH=$HOME/code/20-questions:$HOME/code/20-questions/OFA:$HOME/code/20-questions/OFA/fairseq GOOGLE_APPLICATION_CREDENTIALS=secrets/google-credentials.json gunicorn -k uvicorn.workers.UvicornWorker -b :9080 questions.inference_server.inference_server:app --timeout 180000 --workers 1
 ```
 Then go to localhost:9080/docs to use the API
+
+### Speech To Text Endpoint
+
+The API supports transcription of audio via the `/api/v1/audio-extraction` and `/api/v1/audio-file-extraction` routes.
+Example usage with `curl`:
+
+```bash
+curl -X POST "http://localhost:9080/api/v1/audio-extraction" \
+     -H "Content-Type: application/json" \
+     -d '{"audio_url": "AUDIO_URL", "translate_to_english": false}'
+```
+
 #### run audio server only
 
 Just the Parakeet speech to text part.

--- a/main.py
+++ b/main.py
@@ -878,6 +878,16 @@ async def text_to_speech(request: Request):
         "templates/text-to-speech.jinja2", base_vars,
     )
 
+
+@app.get("/speech-to-text")
+async def speech_to_text(request: Request):
+    base_vars = get_base_template_vars(request)
+    base_vars.update({
+    })
+    return templates.TemplateResponse(
+        "templates/speech-to-text.jinja2", base_vars,
+    )
+
 @app.get("/use-cases/{usecase}")
 async def use_case_route(request: Request, usecase: str):
     use_case_data = deepcopy(fixtures.use_cases.get(usecase))

--- a/static/templates/shared/header.jinja2
+++ b/static/templates/shared/header.jinja2
@@ -14,6 +14,7 @@
 
             <a class="mdl-navigation__link" href="/tools">Tools</a>
             <a class="mdl-navigation__link" href="/text-to-speech">Text To Speech</a>
+            <a class="mdl-navigation__link" href="/speech-to-text">Speech To Text</a>
 
             <a class="mdl-navigation__link" href="/bulk-text-generator">Bulk Generator</a>
             <a class="mdl-navigation__link" href="/playground">Playground</a>
@@ -38,6 +39,7 @@
         <a class="mdl-navigation__link" href="/playground"><i class="material-icons dp48">play_arrow</i> Playground</a>
         <a class="mdl-navigation__link" href="/ai-text-editor"><i class="material-icons dp48">edit</i> AI Text Editor</a>
         <a class="mdl-navigation__link" href="/text-to-speech"><i class="material-icons dp48">volume_up</i> Text To Speech</a>
+        <a class="mdl-navigation__link" href="/speech-to-text"><i class="material-icons dp48">graphic_eq</i> Speech To Text</a>
         <a class="mdl-navigation__link" href="/docs"><i class="material-icons dp48">android</i> Docs</a>
         <a class="header-login-signup mdl-navigation__link" href="#" onclick="showLoginModal()"><i class="material-icons dp48">login</i> Login</a>
         <a class="header-subscribe mdl-navigation__link" href="/subscribe"><i class="material-icons dp48">payments</i> Subscribe</a>

--- a/static/templates/shared/header_new.jinja2
+++ b/static/templates/shared/header_new.jinja2
@@ -14,6 +14,7 @@
 
             <a class="mdl-navigation__link" href="/tools">Tools</a>
             <a class="mdl-navigation__link" href="/text-to-speech">Text To Speech</a>
+            <a class="mdl-navigation__link" href="/speech-to-text">Speech To Text</a>
 
             <a class="mdl-navigation__link" href="/bulk-text-generator">Bulk Generator</a>
             <a class="mdl-navigation__link" href="/playground">Playground</a>
@@ -38,6 +39,7 @@
         <a class="mdl-navigation__link" href="/playground"><i class="material-icons dp48">play_arrow</i> Playground</a>
         <a class="mdl-navigation__link" href="/ai-text-editor"><i class="material-icons dp48">edit</i> AI Text Editor</a>
         <a class="mdl-navigation__link" href="/text-to-speech"><i class="material-icons dp48">volume_up</i> Text To Speech</a>
+        <a class="mdl-navigation__link" href="/speech-to-text"><i class="material-icons dp48">graphic_eq</i> Speech To Text</a>
         <a class="mdl-navigation__link" href="/docs"><i class="material-icons dp48">android</i> Docs</a>
         <a class="header-login-signup mdl-navigation__link" href="#" onclick="showLoginModal()"><i class="material-icons dp48">login</i> Login</a>
         <a class="header-subscribe mdl-navigation__link" href="/subscribe"><i class="material-icons dp48">payments</i> Subscribe</a>

--- a/static/templates/shared/header_old.jinja2
+++ b/static/templates/shared/header_old.jinja2
@@ -14,6 +14,7 @@
 
             <a class="mdl-navigation__link" href="/tools">Tools</a>
             <a class="mdl-navigation__link" href="/text-to-speech">Text To Speech</a>
+            <a class="mdl-navigation__link" href="/speech-to-text">Speech To Text</a>
 
             <a class="mdl-navigation__link" href="/bulk-text-generator">Bulk Generator</a>
             <a class="mdl-navigation__link" href="/playground">Playground</a>
@@ -38,6 +39,7 @@
         <a class="mdl-navigation__link" href="/playground"><i class="material-icons dp48">play_arrow</i> Playground</a>
         <a class="mdl-navigation__link" href="/ai-text-editor"><i class="material-icons dp48">edit</i> AI Text Editor</a>
         <a class="mdl-navigation__link" href="/text-to-speech"><i class="material-icons dp48">volume_up</i> Text To Speech</a>
+        <a class="mdl-navigation__link" href="/speech-to-text"><i class="material-icons dp48">graphic_eq</i> Speech To Text</a>
         <a class="mdl-navigation__link" href="/docs"><i class="material-icons dp48">android</i> Docs</a>
         <a class="header-login-signup mdl-navigation__link" href="#" onclick="showLoginModal()"><i class="material-icons dp48">login</i> Login</a>
         <a class="header-subscribe mdl-navigation__link" href="/subscribe"><i class="material-icons dp48">payments</i> Subscribe</a>


### PR DESCRIPTION
## Summary
- expose new `/speech-to-text` route in `main.py`
- link to new demo page in the navigation headers
- document speech-to-text API usage in README

## Testing
- `PYTHONPATH=. pytest tests/test_chat_openai.py -q` *(fails: file not found)*

------
https://chatgpt.com/codex/tasks/task_e_686f61b67074833393d3cedb04ae62ae