### PR TITLE
Add Postgres workflow and basic tests

### DIFF
--- a/.github/workflows/postgres-tests.yml
+++ b/.github/workflows/postgres-tests.yml
@@ -1,0 +1,38 @@
+name: Postgres Tests
+on:
+  push:
+  pull_request:
+
+jobs:
+  postgres:
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:15
+        env:
+          POSTGRES_DB: textgen
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: password
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd="pg_isready -U postgres" --health-interval=10s --health-timeout=5s --health-retries=5
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+      - name: Install uv
+        run: python -m pip install astral-uv
+      - name: Install dependencies
+        run: |
+          uv pip install -r requirements.txt
+          uv pip install -r dev-requirements.txt
+          uv pip install -r questions/inference_server/requirements.txt
+      - name: Wait for Postgres
+        run: until pg_isready -h localhost -p 5432; do sleep 1; done
+      - name: Run tests
+        env:
+          DATABASE_URL: postgresql://postgres:password@localhost:5432/textgen
+        run: |
+          PYTHONPATH=. pytest tests/test_postgres_setup.py tests/test_frontend.py -q

--- a/tests/test_frontend.py
+++ b/tests/test_frontend.py
@@ -1,0 +1,10 @@
+from fastapi.testclient import TestClient
+import main
+
+client = TestClient(main.app)
+
+
+def test_index_page():
+    response = client.get("/")
+    assert response.status_code == 200
+    assert "Text Generator" in response.text

--- a/tests/test_postgres_setup.py
+++ b/tests/test_postgres_setup.py
@@ -1,0 +1,34 @@
+import os
+import pytest
+from sqlalchemy import create_engine, text
+from sqlalchemy.orm import sessionmaker
+from questions.db_models_postgres import Base, User
+
+DATABASE_URL = os.getenv("DATABASE_URL", "postgresql://postgres:password@localhost:5432/textgen")
+
+engine = create_engine(DATABASE_URL)
+SessionLocal = sessionmaker(bind=engine)
+
+@pytest.fixture(scope="module")
+def setup_db():
+    Base.metadata.create_all(engine)
+    yield
+    Base.metadata.drop_all(engine)
+
+
+def test_postgres_connection(setup_db):
+    with engine.connect() as conn:
+        result = conn.execute(text("SELECT 1")).scalar()
+        assert result == 1
+
+
+def test_user_crud(setup_db):
+    session = SessionLocal()
+    user = User(id="test_user", email="test@example.com", secret="s", password_hash="h")
+    session.add(user)
+    session.commit()
+    fetched = session.query(User).filter_by(id="test_user").first()
+    assert fetched is not None
+    session.delete(fetched)
+    session.commit()
+    session.close()


### PR DESCRIPTION
## Summary
- add `postgres-tests.yml` workflow for GitHub Actions
- add basic Postgres connectivity tests
- add simple frontend test using FastAPI TestClient

## Testing
- `python3.11 -m pytest tests/test_postgres_setup.py -q` *(fails: connection refused)*
- `python3.11 -m pytest tests/test_frontend.py -q` *(fails: ModuleNotFoundError: boto3)*

------
https://chatgpt.com/codex/tasks/task_e_6870e49f16248333a18f9f80d9fec79f